### PR TITLE
refactor: add and use abstract entities

### DIFF
--- a/src/common/abstract-with-uuid.entity.ts
+++ b/src/common/abstract-with-uuid.entity.ts
@@ -1,0 +1,20 @@
+import {
+  CreateDateColumn,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export abstract class AbstratEntityWithUUID {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @CreateDateColumn({
+    type: 'timestamp without time zone',
+  })
+  createdAt: Date;
+
+  @UpdateDateColumn({
+    type: 'timestamp without time zone',
+  })
+  updatedAt: Date;
+}

--- a/src/common/abstract.entity.ts
+++ b/src/common/abstract.entity.ts
@@ -1,0 +1,20 @@
+import {
+  CreateDateColumn,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export abstract class AbstratEntity {
+  @PrimaryGeneratedColumn()
+  id: string;
+
+  @CreateDateColumn({
+    type: 'timestamp with time zone',
+  })
+  createdAt: Date;
+
+  @UpdateDateColumn({
+    type: 'timestamp with time zone',
+  })
+  updatedAt: Date;
+}

--- a/src/modules/users/user.entity.ts
+++ b/src/modules/users/user.entity.ts
@@ -1,12 +1,10 @@
 import { Exclude } from 'class-transformer';
-import { BeforeInsert, Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { BeforeInsert, Column, Entity } from 'typeorm';
+import { AbstratEntityWithUUID } from 'src/common/abstract-with-uuid.entity';
 import * as bcrypt from 'bcrypt';
 
 @Entity()
-export class User {
-  @PrimaryGeneratedColumn('uuid')
-  id: number;
-
+export class User extends AbstratEntityWithUUID {
   @Column({ unique: true })
   email: string;
 


### PR DESCRIPTION
- Use abstract entity to reduce code repetition.
- Add `createdAt` and `updatedAt` columns.